### PR TITLE
add numberOfLines to multiline TextInputs

### DIFF
--- a/frontend/Pages/ConversationPage/index.tsx
+++ b/frontend/Pages/ConversationPage/index.tsx
@@ -223,6 +223,7 @@ export const ConversationPage: React.FC<ConversationPageProps> = ({ route }) => 
         <TextInput
           mode='outlined'
           multiline
+          numberOfLines={5}
           label={t('conversationPage.typeMessage') ?? ''}
           value={input}
           onChangeText={setInput}

--- a/frontend/Pages/ProfileConfigPage/index.tsx
+++ b/frontend/Pages/ProfileConfigPage/index.tsx
@@ -470,6 +470,7 @@ export const ProfileConfigPage: React.FC = () => {
           <TextInput
             mode='outlined'
             multiline
+            numberOfLines={5}
             label={t('profileConfigPage.lud06Label') ?? ''}
             onChangeText={setLnurl}
             value={lnurl}

--- a/frontend/Pages/ProfileConnectPage/index.tsx
+++ b/frontend/Pages/ProfileConnectPage/index.tsx
@@ -68,6 +68,7 @@ export const ProfileConnectPage: React.FC = () => {
           <TextInput
             mode='outlined'
             multiline
+            numberOfLines={5}
             label={label}
             onChangeText={setInputValue}
             value={inputValue}


### PR DESCRIPTION
as requested in https://github.com/KoalaSat/nostros/pull/179#issuecomment-1403377736, i added the `numberOfLines` attribute to each of the TextInputs that were multiline that did not have a max number of lines. i decided on five lines simply because i saw there was a TextInput in there that already had `numberOfLines` set to five. luckily, changing this attribute is simple.